### PR TITLE
Add hero section below navigation

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -87,7 +87,54 @@ ul, ol {
 }
 
 /*----------------------------*\
-	Buttons
+        Hero
+\*----------------------------*/
+
+.hero {
+  position: relative;
+  background-image: url('../img/splash.jpg');
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+  color: #FFF;
+  padding: 80px 0;
+  overflow: hidden;
+}
+
+.hero::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(21, 22, 29, 0.65);
+}
+
+.hero .container {
+  position: relative;
+  z-index: 1;
+}
+
+.hero-content {
+  max-width: 520px;
+}
+
+.hero-content h1 {
+  font-size: 48px;
+  line-height: 1.2;
+  margin-bottom: 20px;
+  color: #FFF;
+}
+
+.hero-content p {
+  font-size: 18px;
+  margin-bottom: 30px;
+  color: #FBFBFC;
+}
+
+/*----------------------------*\
+        Buttons
 \*----------------------------*/
 
 .primary-btn {

--- a/index.html
+++ b/index.html
@@ -206,12 +206,24 @@ s0.parentNode.insertBefore(s1,s0);
 			</div>
 			<!-- /container -->
 		</nav>
-		<!-- /NAVIGATION -->
+                <!-- /NAVIGATION -->
 
-		<!-- SECTION -->
-		<div class="section">
+                <!-- HERO -->
+                <section class="hero">
+                        <div class="container">
+                                <div class="hero-content">
+                                        <h1>Resource Rich Style, Delivered</h1>
+                                        <p>Discover new drops, restocked favorites, and gear that represents your grind.</p>
+                                        <a class="primary-btn" href="#my-store-31021210">Shop the Collection</a>
+                                </div>
+                        </div>
+                </section>
+                <!-- /HERO -->
 
-			<!-- container -->
+                <!-- SECTION -->
+                <div class="section">
+
+                        <!-- container -->
 			<div class="container">
 				<!-- row -->
 				<div class="row">


### PR DESCRIPTION
## Summary
- add a full-width hero section directly under the navigation menu
- style the hero with a background image overlay and typography adjustments

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d936c4c6c883228df5a496b5384f9a